### PR TITLE
Fix export_TF

### DIFF
--- a/src/napari_noise2void/_widget.py
+++ b/src/napari_noise2void/_widget.py
@@ -72,7 +72,7 @@ def train_noise2void(training_image: "napari.types.ImageData",
     model.export_TF(name=model_filename,
                     description=model_description,
                     authors=model_authors.split(","),
-                    test_img=X_val[0, ..., 0], axes=axes,
+                    test_img=X_val[0, ..., 0], axes=axes[:-1],
                     patch_shape=patch_shape)
 
     return apply_noise2void(training_image, model_filename=model_filename)


### PR DESCRIPTION
## Issue

I got the following error when I run the training.

```
File /home/user/miniconda3/envs/napari/lib/python3.8/site-packages/napari_noise2void/_widget.py:72, in train_noise2void(training_image=<class 'numpy.ndarray'> (2500, 1690) float32, validation_image=<class 'numpy.ndarray'> (471, 1690) float32, number_training_epochs=10, train_batch_size=4, n2v_perc_pix=0.2, model_filename='my_model_n2v', model_description='none', model_authors='unknown')
     69 # We are ready to start training now.
     70 history = model.train(X, X_val)
---> 72 model.export_TF(name=model_filename,
        model = N2V(my_model_n2v): YXC → YXC
├─ Directory: /home/user/repositories/napari-noise2void/models/my_model_n2v
└─ N2VConfig(axes='YXC', batch_norm=True, blurpool=False, means=['39180.457'], n2v_manipulator='uniform_withCP', n2v_neighborhood_radius=5, n2v_patch_shape=(64, 64), n2v_perc_pix=0.2, n_channel_in=1, n_channel_out=1, n_dim=2, probabilistic=False, single_net_per_channel=True, skip_skipone=False, stds=['18693.227'], structN2Vmask=None, train_batch_size=4, train_checkpoint='weights_best.h5', train_epochs=10, train_learning_rate=0.0004, train_loss='mse', train_reduce_lr={'factor': 0.5, 'patience': 10, 'verbose': True}, train_steps_per_epoch=63, train_tensorboard=True, unet_input_shape=(None, None, 1), unet_kern_size=3, unet_last_activation='linear', unet_n_depth=2, unet_n_first=32, unet_residual=False)
        model_filename = 'my_model_n2v'
        model_description = 'none'
        model_authors = 'unknown'
        X_val = <class 'numpy.ndarray'> (1456, 64, 64, 1) float32
        axes = 'YXC'
        patch_shape = (64, 64)
     73                 description=model_description,
     74                 authors=model_authors.split(","),
     75                 test_img=X_val[0, ..., 0], axes=axes,
     76                 patch_shape=patch_shape)
     78 return apply_noise2void(training_image, model_filename=model_filename)

File /home/user/miniconda3/envs/napari/lib/python3.8/site-packages/csbdeep/models/base_model.py:32, in suppress_without_basedir.<locals>._suppress_without_basedir.<locals>.wrapper(*args=(N2V(my_model_n2v): YXC → YXC
├─ Directory: /mnt/..._n_depth=2, unet_n_first=32, unet_residual=False),), **kwargs={'authors': ['unknown'], 'axes': 'YXC', 'description': 'none', 'name': 'my_model_n2v', 'patch_shape': (64, 64), 'test_img': <class 'numpy.ndarray'> (64, 64) float32})
     30     warn is False or warnings.warn("Suppressing call of '%s' (due to basedir=None)." % f.__name__)
     31 else:
---> 32     return f(*args, **kwargs)
        f = <function N2V.export_TF at 0x7f07a8dd6430>
        args = (N2V(my_model_n2v): YXC → YXC
├─ Directory: /home/user/repositories/napari-noise2void/models/my_model_n2v
└─ N2VConfig(axes='YXC', batch_norm=True, blurpool=False, means=['39180.457'], n2v_manipulator='uniform_withCP', n2v_neighborhood_radius=5, n2v_patch_shape=(64, 64), n2v_perc_pix=0.2, n_channel_in=1, n_channel_out=1, n_dim=2, probabilistic=False, single_net_per_channel=True, skip_skipone=False, stds=['18693.227'], structN2Vmask=None, train_batch_size=4, train_checkpoint='weights_best.h5', train_epochs=10, train_learning_rate=0.0004, train_loss='mse', train_reduce_lr={'factor': 0.5, 'patience': 10, 'verbose': True}, train_steps_per_epoch=63, train_tensorboard=True, unet_input_shape=(None, None, 1), unet_kern_size=3, unet_last_activation='linear', unet_n_depth=2, unet_n_first=32, unet_residual=False),)
        kwargs = {'name': 'my_model_n2v', 'description': 'none', 'authors': ['unknown'], 'test_img': <class 'numpy.ndarray'> (64, 64) float32, 'axes': 'YXC', 'patch_shape': (64, 64)}

File /home/user/miniconda3/envs/napari/lib/python3.8/site-packages/n2v/models/n2v_standard.py:451, in N2V.export_TF(self=N2V(my_model_n2v): YXC → YXC
├─ Directory: /mnt/..._n_depth=2, unet_n_first=32, unet_residual=False), name='my_model_n2v', description='none', authors=['unknown'], test_img=<class 'numpy.ndarray'> (64, 64) float32, axes='YXC', patch_shape=(64, 64), fname=PosixPath('models/my_model_n2v/export.bioimage.io.zip'))
    449 if 'C' in axes:
    450     input_n_dims -= 1
--> 451 assert input_n_dims == self.config.n_dim, 'Input and network dimensions do not match.'
        input_n_dims = 1
        input_n_dims == self.config.n_dim = False
        self.config.n_dim = 2
        self.config = N2VConfig(axes='YXC', batch_norm=True, blurpool=False, means=['39180.457'], n2v_manipulator='uniform_withCP', n2v_neighborhood_radius=5, n2v_patch_shape=(64, 64), n2v_perc_pix=0.2, n_channel_in=1, n_channel_out=1, n_dim=2, probabilistic=False, single_net_per_channel=True, skip_skipone=False, stds=['18693.227'], structN2Vmask=None, train_batch_size=4, train_checkpoint='weights_best.h5', train_epochs=10, train_learning_rate=0.0004, train_loss='mse', train_reduce_lr={'factor': 0.5, 'patience': 10, 'verbose': True}, train_steps_per_epoch=63, train_tensorboard=True, unet_input_shape=(None, None, 1), unet_kern_size=3, unet_last_activation='linear', unet_n_depth=2, unet_n_first=32, unet_residual=False)
        self = N2V(my_model_n2v): YXC → YXC
├─ Directory: /home/user/repositories/napari-noise2void/models/my_model_n2v
└─ N2VConfig(axes='YXC', batch_norm=True, blurpool=False, means=['39180.457'], n2v_manipulator='uniform_withCP', n2v_neighborhood_radius=5, n2v_patch_shape=(64, 64), n2v_perc_pix=0.2, n_channel_in=1, n_channel_out=1, n_dim=2, probabilistic=False, single_net_per_channel=True, skip_skipone=False, stds=['18693.227'], structN2Vmask=None, train_batch_size=4, train_checkpoint='weights_best.h5', train_epochs=10, train_learning_rate=0.0004, train_loss='mse', train_reduce_lr={'factor': 0.5, 'patience': 10, 'verbose': True}, train_steps_per_epoch=63, train_tensorboard=True, unet_input_shape=(None, None, 1), unet_kern_size=3, unet_last_activation='linear', unet_n_depth=2, unet_n_first=32, unet_residual=False)
    452 assert test_img.shape[axes.index('X')] == test_img.shape[
    453     axes.index('Y')], 'X and Y dimensions are not of same length.'
    454 test_output = self.predict(test_img, axes)

AssertionError: Input and network dimensions do not match.
```
## Cause

`test_img` is specified excluding the `C` dimension, while `axes` includes it.

https://github.com/haesleinhuepf/napari-noise2void/blob/f9865684f403e7e47e927fe42ad21b7114a0dd1f/src/napari_noise2void/_widget.py#L37-L44

https://github.com/haesleinhuepf/napari-noise2void/blob/f9865684f403e7e47e927fe42ad21b7114a0dd1f/src/napari_noise2void/_widget.py#L72-L76

## Solution

Exclude the `C` dimension from  `axes`.

```py
    model.export_TF(name=model_filename,
                    description=model_description,
                    authors=model_authors.split(","),
                    test_img=X_val[0, ..., 0], axes=axes[:-1],
                    patch_shape=patch_shape)
```
