### PR TITLE
Conform patch_shape for N2V_DataGenerator

### DIFF
--- a/src/napari_noise2void/_widget.py
+++ b/src/napari_noise2void/_widget.py
@@ -43,9 +43,12 @@ def train_noise2void(training_image: "napari.types.ImageData",
     else:
         raise ValueError("Only 2D and 3D data supported.")
 
+    # Conform patch_shape for N2V_DataGenerator
+    patch_shape = tuple(min(4 * ((s - 1) // 4), ps) for s, ps in zip(training_image.shape, patch_shape))
+
     data = np.asarray([training_image[..., np.newaxis]])
     data.shape
-    print("data shope", data.shape)
+    print("data shape", data.shape)
 
     X = datagen.generate_patches(data, shape=patch_shape)
     X_val = datagen.generate_patches(np.asarray([validation_image[...,np.newaxis]]), shape=patch_shape)


### PR DESCRIPTION
## Issue

I got the following error when I input the 3D image data with the shape `(15, 748, 1024)`.

```
AssertionError: Input and network dimensions do not match.
you have selected (15, 748, 1024)
data shope (1, 15, 748, 1024, 1)
'shape' is too big.
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File /home/user/applications/miniconda3/envs/napari/lib/python3.8/site-packages/magicgui/widgets/_bases/value_widget.py:57, in ValueWidget._on_value_change(self=PushButton(value=False, annotation=None, name='call_button'), value=False)
     55 if value is self.null_value and not self._nullable:
     56     return
---> 57 self.changed.emit(value)
        value = False
        self.changed = <SignalInstance 'changed' on PushButton(value=False, annotation=None, name='call_button')>
        self = PushButton(value=False, annotation=None, name='call_button')

File /home/user/applications/miniconda3/envs/napari/lib/python3.8/site-packages/psygnal/_signal.py:725, in psygnal._signal.SignalInstance.emit()

File /home/user/applications/miniconda3/envs/napari/lib/python3.8/site-packages/psygnal/_signal.py:767, in psygnal._signal.SignalInstance._run_emit_loop()

File /home/user/applications/miniconda3/envs/napari/lib/python3.8/site-packages/psygnal/_signal.py:768, in psygnal._signal.SignalInstance._run_emit_loop()

File /home/user/applications/miniconda3/envs/napari/lib/python3.8/site-packages/psygnal/_signal.py:788, in psygnal._signal.SignalInstance._run_emit_loop()

File /home/user/applications/miniconda3/envs/napari/lib/python3.8/site-packages/magicgui/widgets/_function_gui.py:207, in FunctionGui.__init__.<locals>._disable_button_and_call()
    205 self._call_button.enabled = False
    206 try:
--> 207     self.__call__()
        self = <FunctionGui train_noise2void(training_image: <function NewType.<locals>.new_type at 0x7f0a9d1f04c0> = <class 'numpy.ndarray'> (15, 748, 1024) uint8, validation_image: <function NewType.<locals>.new_type at 0x7f0a9d1f04c0> = <class 'numpy.ndarray'> (15, 748, 1024) uint8, number_training_epochs: int = 10, train_batch_size: int = 4, n2v_perc_pix=0.2, model_filename: str = 'my_model_n2v', model_description: str = 'none', model_authors: str = 'unknown') -> <function NewType.<locals>.new_type at 0x7f0a9d1f04c0>>
    208 finally:
    209     self._call_button.enabled = True

File /home/user/applications/miniconda3/envs/napari/lib/python3.8/site-packages/magicgui/widgets/_function_gui.py:318, in FunctionGui.__call__(self=<FunctionGui train_noise2void(training_image: <f...nknown') -> <function NewType.<locals>.new_type>>, update_widget=False, *args=(), **kwargs={})
    316 self._tqdm_depth = 0  # reset the tqdm stack count
    317 with _function_name_pointing_to_widget(self):
--> 318     value = self._function(*bound.args, **bound.kwargs)
        self = <FunctionGui train_noise2void(training_image: <function NewType.<locals>.new_type at 0x7f0a9d1f04c0> = <class 'numpy.ndarray'> (15, 748, 1024) uint8, validation_image: <function NewType.<locals>.new_type at 0x7f0a9d1f04c0> = <class 'numpy.ndarray'> (15, 748, 1024) uint8, number_training_epochs: int = 10, train_batch_size: int = 4, n2v_perc_pix=0.2, model_filename: str = 'my_model_n2v', model_description: str = 'none', model_authors: str = 'unknown') -> <function NewType.<locals>.new_type at 0x7f0a9d1f04c0>>
        bound = <BoundArguments (training_image=<class 'numpy.ndarray'> (15, 748, 1024) uint8, validation_image=<class 'numpy.ndarray'> (15, 748, 1024) uint8, number_training_epochs=10, train_batch_size=4, n2v_perc_pix=0.2, model_filename='my_model_n2v', model_description='none', model_authors='unknown')>
        self._function = <function train_noise2void at 0x7f07eb4e9550>
    320 self._call_count += 1
    321 if self._result_widget is not None:

File /home/user/applications/miniconda3/envs/napari/lib/python3.8/site-packages/napari_noise2void/_widget.py:50, in train_noise2void(training_image=<class 'numpy.ndarray'> (15, 748, 1024) uint8, validation_image=<class 'numpy.ndarray'> (15, 748, 1024) uint8, number_training_epochs=10, train_batch_size=4, n2v_perc_pix=0.2, model_filename='my_model_n2v', model_description='none', model_authors='unknown')
     47 data.shape
     48 print("data shope", data.shape)
---> 50 X = datagen.generate_patches(data, shape=patch_shape)
        datagen = <n2v.internals.N2V_DataGenerator.N2V_DataGenerator object at 0x7f0a63132640>
        data = <class 'numpy.ndarray'> (1, 15, 748, 1024, 1) uint8
        patch_shape = (32, 64, 64)
     51 X_val = datagen.generate_patches(np.asarray([validation_image[...,np.newaxis]]), shape=patch_shape)
     53 config = N2VConfig(X, unet_kern_size=3,
     54                    train_steps_per_epoch=int(X.shape[0] / 128),
     55                    train_epochs=number_training_epochs,
   (...)
     61                    n2v_manipulator='uniform_withCP',
     62                    n2v_neighborhood_radius=5)

File /home/user/applications/miniconda3/envs/napari/lib/python3.8/site-packages/n2v/internals/N2V_DataGenerator.py:172, in N2V_DataGenerator.generate_patches(self=<n2v.internals.N2V_DataGenerator.N2V_DataGenerator object>, data=<class 'numpy.ndarray'> (1, 15, 748, 1024, 1) uint8, num_patches=None, shape=(32, 64, 64), augment=True)
    170 if shape[-2] == shape[-1]:
    171     if augment:
--> 172         patches = self.__augment_patches__(patches=patches)
        patches = None
        self = <n2v.internals.N2V_DataGenerator.N2V_DataGenerator object at 0x7f0a63132640>
    173 else:
    174     if augment:

File /home/user/applications/miniconda3/envs/napari/lib/python3.8/site-packages/n2v/internals/N2V_DataGenerator.py:240, in N2V_DataGenerator.__augment_patches__(self=<n2v.internals.N2V_DataGenerator.N2V_DataGenerator object>, patches=None)
    239 def __augment_patches__(self, patches):
--> 240     if len(patches.shape[1:-1]) == 2:
        patches = None
    241         augmented = np.concatenate((patches,
    242                                     np.rot90(patches, k=1, axes=(1, 2)),
    243                                     np.rot90(patches, k=2, axes=(1, 2)),
    244                                     np.rot90(patches, k=3, axes=(1, 2))))
    245     elif len(patches.shape[1:-1]) == 3:

AttributeError: 'NoneType' object has no attribute 'shape'

```

## Cause

`N2V_DataGenerator` expects to have a patch shape that follows the rules below:
- each dimension is smaller or equal to the image shape
- each dimension is evenly divisible by 4

Currently, the `patch_shape` is specified as `(64, 64)` for 2D and `(32, 64, 64)` for 3D data.

https://github.com/haesleinhuepf/napari-noise2void/blob/3ae3feecd4f8a53797e0e26123aab92d7d59d03b/src/napari_noise2void/_widget.py#L37-L44

When we input an image smaller than the `patch_shape`, this issue happens.

## Solution

Conform the `patch_shape` to satisfy `N2V_DataGenerator`'s requirements.

```
patch_shape = tuple(min(4 * ((s - 1) // 4), ps) for s, ps in zip(training_image.shape, patch_shape))
```